### PR TITLE
Add initial Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: android
+# Allows to install dependencies via apt-get when using Travis's new container-based infrastructure.
+sudo: false
+android:
+  components:
+    # Note that the tools section appears twice on purpose as it’s required to get the newest Android SDK tools.
+    - tools
+    - platform-tools
+    - tools
+    - build-tools-25.0.3
+    - android-25
+    - extra-android-m2repository


### PR DESCRIPTION
Allows enabling Travis CI for the project. It is only a half of configuration second part of the setup requires visiting [https://travis-ci.org/](https://travis-ci.org/). More on this [Integrate Travis CI with your GitHub repo](https://github.com/mbonaci/mbo-storm/wiki/Integrate-Travis-CI-with-your-GitHub-repo).

There is still a room for improvement like to add a batch, as soon as I have no access to concrete URL. I have not included the update to the README.