### PR TITLE
Fix shimmer line starting position

### DIFF
--- a/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
+++ b/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
@@ -288,7 +288,14 @@ public class ShimmerLayout extends FrameLayout {
         }
 
         final int animationToX = getWidth();
-        final int animationFromX = -animationToX;
+        final int animationFromX;
+
+        if (getWidth() > maskRect.width()) {
+            animationFromX = -animationToX;
+        } else {
+            animationFromX = -maskRect.width();
+        }
+
         final int shimmerBitmapWidth = maskRect.width();
         final int shimmerAnimationFullLength = animationToX - animationFromX;
 


### PR DESCRIPTION
Now the animation will start from the edge of the view, even if the angle has the maximum value and the height is much bigger than the width.

#33 

![animation_start_point_fix](https://user-images.githubusercontent.com/22046406/33810597-05d896e4-de07-11e7-9377-ce4d08874ba8.gif)
