### PR TITLE
Allow recycled views in RecyclerViewer to animate

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-include ':app', ':shimmerlayout'

--- a/shimmerlayout/build.gradle
+++ b/shimmerlayout/build.gradle
@@ -1,15 +1,4 @@
 apply plugin: 'com.android.library'
+apply from: "$rootDir/shared.gradle"
 
-android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.1"
-
-    defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 27
-        versionCode 1
-        versionName "0.1.0"
-    }
-}
-
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
+++ b/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
@@ -51,7 +51,7 @@ public class ShimmerLayout extends FrameLayout {
     private float maskWidth;
     private float gradientCenterColorWidth;
 
-    private ViewTreeObserver.OnGlobalLayoutListener startAnimationGlobalLayoutListener;
+    private ViewTreeObserver.OnPreDrawListener startAnimationOnPreDrawListener;
 
     public ShimmerLayout(Context context) {
         this(context, null);
@@ -129,15 +129,16 @@ public class ShimmerLayout extends FrameLayout {
         }
 
         if (getWidth() == 0) {
-            startAnimationGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
+            startAnimationOnPreDrawListener = new ViewTreeObserver.OnPreDrawListener() {
                 @Override
-                public void onGlobalLayout() {
-                    removeGlobalLayoutListener(this);
+                public boolean onPreDraw() {
+                    getViewTreeObserver().removeOnPreDrawListener(this);
                     startShimmerAnimation();
+                    return true;
                 }
             };
 
-            getViewTreeObserver().addOnGlobalLayoutListener(startAnimationGlobalLayoutListener);
+            getViewTreeObserver().addOnPreDrawListener(startAnimationOnPreDrawListener);
 
             return;
         }
@@ -148,8 +149,8 @@ public class ShimmerLayout extends FrameLayout {
     }
 
     public void stopShimmerAnimation() {
-        if (startAnimationGlobalLayoutListener != null) {
-            removeGlobalLayoutListener(startAnimationGlobalLayoutListener);
+        if (startAnimationOnPreDrawListener != null) {
+            getViewTreeObserver().removeOnPreDrawListener(startAnimationOnPreDrawListener);
         }
 
         resetShimmering();
@@ -383,14 +384,6 @@ public class ShimmerLayout extends FrameLayout {
         } else {
             //noinspection deprecation
             return getResources().getColor(id);
-        }
-    }
-
-    private void removeGlobalLayoutListener(ViewTreeObserver.OnGlobalLayoutListener listener) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            getViewTreeObserver().removeOnGlobalLayoutListener(listener);
-        } else {
-            getViewTreeObserver().removeGlobalOnLayoutListener(listener);
         }
     }
 

--- a/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
+++ b/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
@@ -98,7 +98,7 @@ public class ShimmerLayout extends FrameLayout {
 
     @Override
     protected void onDetachedFromWindow() {
-        resetShimmering();
+        //resetShimmering();
         super.onDetachedFromWindow();
     }
 


### PR DESCRIPTION
Switching from OnGlobalLayoutListener to OnPreDrawListener
should allow to start animation for recycled view, which
width is not calculated but previous OnGlobalLayoutListener
is not called.

Fixes #38