### PR TITLE
fix bug with incorrect shimmering size after requestLayout called

### DIFF
--- a/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
+++ b/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
@@ -93,6 +93,14 @@ public class ShimmerLayout extends FrameLayout {
     }
 
     @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        if (changed) {
+            updateShimmerAnimation();
+        }
+    }
+
+    @Override
     protected void onDetachedFromWindow() {
         resetShimmering();
         super.onDetachedFromWindow();
@@ -140,7 +148,35 @@ public class ShimmerLayout extends FrameLayout {
             return;
         }
 
-        Animator animator = getShimmerAnimation();
+        Animator animator = getShimmerAnimation(0);
+        animator.start();
+        isAnimationStarted = true;
+    }
+
+    private void updateShimmerAnimation() {
+        if (!isAnimationStarted) {
+            return;
+        }
+        long currentPlayTime = maskAnimator.getCurrentPlayTime();
+
+        if (getWidth() == 0 || isLayoutRequested()) {
+            startAnimationPreDrawListener = new ViewTreeObserver.OnPreDrawListener() {
+                @Override
+                public boolean onPreDraw() {
+                    getViewTreeObserver().removeOnPreDrawListener(this);
+                    updateShimmerAnimation();
+                    return true;
+                }
+            };
+
+            getViewTreeObserver().addOnPreDrawListener(startAnimationPreDrawListener);
+
+            return;
+        }
+        if (maskAnimator != null) {
+            resetShimmering();
+        }
+        Animator animator = getShimmerAnimation(currentPlayTime);
         animator.start();
         isAnimationStarted = true;
     }
@@ -321,7 +357,7 @@ public class ShimmerLayout extends FrameLayout {
         gradientTexturePaint.setShader(composeShader);
     }
 
-    private Animator getShimmerAnimation() {
+    private Animator getShimmerAnimation(long currentPlayTime) {
         if (maskAnimator != null) {
             return maskAnimator;
         }
@@ -346,6 +382,7 @@ public class ShimmerLayout extends FrameLayout {
                 : ValueAnimator.ofInt(0, shimmerAnimationFullLength);
         maskAnimator.setDuration(shimmerAnimationDuration);
         maskAnimator.setRepeatCount(ObjectAnimator.INFINITE);
+        maskAnimator.setCurrentPlayTime(currentPlayTime);
 
         maskAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override

--- a/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
+++ b/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
@@ -124,7 +124,7 @@ public class ShimmerLayout extends FrameLayout {
             return;
         }
 
-        if (getWidth() == 0) {
+        if (getWidth() == 0 || isLayoutRequested()) {
             startAnimationPreDrawListener = new ViewTreeObserver.OnPreDrawListener() {
                 @Override
                 public boolean onPreDraw() {


### PR DESCRIPTION
There is incorrect shimmer animation after child view has been changed. 
E.g.

```
        childView.setText(newText);
        shimmerLayout.startShimmerAnimation();
```
If length of newText and text in `childView` is differ, than shimmer animation will be not correct