### PR TITLE
incorrect behaviour + memory leak fix

### DIFF
--- a/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
+++ b/shimmerlayout/src/main/java/io/supercharge/shimmerlayout/ShimmerLayout.java
@@ -129,6 +129,7 @@ public class ShimmerLayout extends FrameLayout {
         }
 
         if (getWidth() == 0) {
+            getViewTreeObserver().removeOnPreDrawListener(startAnimationPreDrawListener);
             startAnimationPreDrawListener = new ViewTreeObserver.OnPreDrawListener() {
                 @Override
                 public boolean onPreDraw() {


### PR DESCRIPTION
I found that if we call startAnimation more then once when the view has 0 size we will add 2 PreDrawListeners.
And everything was ok except the case when I cancel shimmer animation before the view size change. In this case - animation will start anyway because `stopShimmerAnimation` will remove only latest PreDrawListener. In this case animation will start anyway.
The second thing - if I navigate back too quick I've noticed that I have a warning about memory leak from LeakCanary. And during the debug found that there can be a case when this PreDrawListener will fire without cancelling and animation will run even if the view is detached.

This PR should fix https://github.com/team-supercharge/ShimmerLayout/issues/75